### PR TITLE
Adds `GraphenePlaygroundView`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,19 @@ urlpatterns = [
 You can pass in any valid GraphQL Playground property as an argument to `GraphQLPlaygroundView.as_view`. A full list of supported properties can be found [here](https://github.com/prisma/graphql-playground#properties)
 
 See `example/` for more details.
+
+
+
+#### Graphene Django GraphiQL Replacement 
+
+You can replace the GraphiQL in the graphene_django GraphQLView by using the `GrapeheneGraphQLView` instead of `GraphQLView`. The `graphiql` argument will now enable/disable the playground instead of GraphiQL.
+
+```python
+# urls.py
+from graphql_playground.graphene import GraphenePlaygroundView
+
+urlpatterns = [
+    ...
+    path('graphql', GraphenePlaygroundView.as_view(graphiql=True)),
+]
+```

--- a/graphql_playground/graphene.py
+++ b/graphql_playground/graphene.py
@@ -1,0 +1,29 @@
+from graphene_django.views import GraphQLView as _GraphQLView
+from .views import GraphQLPlaygroundView as _PlaygroundView
+
+
+
+class GraphenePlaygroundView(_GraphQLView):
+    """ This is a wrapper around :mod:`graphene_django`'s :class:`GraphQLView` that replaces `graphiql` with `graphql-playground`.
+
+    Accepts the same parameters as `GraphQLPlaygroundView`, all others are passed to `GraphQLView`.
+    """
+    def __init__(self, 
+                endpoint=None,
+                subscription_endpoint=None,
+                workspace_name=None,
+                config=None,
+                settings=None,
+                *args, **kwargs):
+
+        kwargs['graphiql'] = True
+        super().__init__(*args, **kwargs)
+        self.playground_view = _PlaygroundView.as_view(
+                 endpoint=endpoint,
+                 subscription_endpoint=subscription_endpoint,
+                 workspace_name=workspace_name,
+                 config=config,
+                 settings=settings)
+
+    def render_graphiql(self, request, **data):
+        return self.playground_view(request)


### PR DESCRIPTION
`GraphenePlaygroundView` can be used to replace `GraphQLView` from `graphene_django` to use the playground view instead of GraphiQL view. 