### PR TITLE
Support tabs property

### DIFF
--- a/graphql_playground/views.py
+++ b/graphql_playground/views.py
@@ -11,6 +11,7 @@ class GraphQLPlaygroundView(TemplateView):
     workspace_name=None
     config=None
     settings=None
+    tabs=None
 
     def __init__(self,
                  endpoint=None,
@@ -26,6 +27,7 @@ class GraphQLPlaygroundView(TemplateView):
             'workspaceName': workspace_name,
             'config': config,
             'settings': settings,
+            'tabs': tabs,
         }
 
     def get_context_data(self, *args, **kwargs):


### PR DESCRIPTION
You can optionally define default tabs array adding 'tabs' as a 'as_view()' param following the 'Tab' interface, according to the graphql-playground documentation